### PR TITLE
fix: correct vpc input assignment in boilerplate terragrunt.hcl template

### DIFF
--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -62,7 +62,7 @@ inputs = {
     }
   )
   {{- else }}
-  {{ .Name }} =
+  {{ .Name }} = local.local_vars.vpc
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
## Summary

- Fix missing value in vpc input assignment: `{{ .Name }} =` was incomplete
- Add `local.local_vars.vpc` as the correct value for the vpc input block

+semver: patch